### PR TITLE
Add and set up logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,14 +26,23 @@ mainClassName = 'com.github.dripolles.projectk.MainKt'
 
 test {
     useJUnitPlatform()
-    testLogging {
-        showStandardStreams = true
-        events = ["started", "skipped", "failed"]
+    testLogging.events = ["passed", "skipped", "failed", "standardOut", "standardError"]
+    afterSuite { desc, result ->
+        if (!desc.parent) { // will match the outermost suite
+            def output = "\nResults: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+            println(output)
+        }
     }
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    implementation "org.apache.logging.log4j:log4j-api-kotlin:1.0.0"
+    implementation "org.apache.logging.log4j:log4j-core:2.11.1"
+    implementation "org.apache.logging.log4j:log4j-api:2.11.1"
+    implementation "org.slf4j:slf4j-simple:1.7.30"
+
+
     implementation "io.ktor:ktor-server-netty:$ktor_version"
 
     testCompile "org.junit.jupiter:junit-jupiter:5.6.2"

--- a/src/main/kotlin/com/github/dripolles/projectk/Main.kt
+++ b/src/main/kotlin/com/github/dripolles/projectk/Main.kt
@@ -6,14 +6,16 @@ import io.ktor.application.install
 import io.ktor.routing.Routing
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
+import org.apache.logging.log4j.kotlin.Logging
 
+object Main : Logging
 
 fun main(args: Array<String>) {
-    println("Hello world")
     val server = embeddedServer(Netty, port = 8080) {
         installFeatures()
         homeModule()
     }
+    Main.logger.debug { "Starting server" }
     server.start(wait = true)
 }
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.github.dripolles.projectk" level="warn" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        <Root level="warn">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/test/kotlin/com/github/dripolles/projectk/HomeTest.kt
+++ b/src/test/kotlin/com/github/dripolles/projectk/HomeTest.kt
@@ -5,10 +5,13 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.TestApplicationEngine
 import io.ktor.server.testing.withTestApplication
+import org.apache.logging.log4j.kotlin.Logging
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class HomeTest {
+    companion object: Logging
+
     private fun withTestProjectK(test: TestApplicationEngine.() -> Unit) {
         withTestApplication(
             {

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="ERROR">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.github.dripolles.projectk" level="debug" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        <Root level="warn">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
I used the wrapper of log4j developed by Apache. One interesting advantage is that it gets the message from a function, which removes the performance hit of generating the message if it's not going to be actually logged.

I added different settings for production and testing, because in tests it's OK to print DEBUG messages but that can cause too much logging in production.

Apart from that, not much to see here.