### PR TITLE
Upload coverage to codecov

### DIFF
--- a/.github/workflows/kotlin-ci.yml
+++ b/.github/workflows/kotlin-ci.yml
@@ -16,3 +16,8 @@ jobs:
         java-version: 1.8
     - run: chmod +x gradlew
     - run: ./gradlew --console=plain test
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./build/reports/jacoco/test/jacocoTestReport.xml

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ plugins {
 apply plugin: 'java'
 apply plugin: 'kotlin'
 apply plugin: 'application'
+apply plugin: 'jacoco'
 
 group 'com.github.dripolles'
 version '1.0-SNAPSHOT'
@@ -36,6 +37,15 @@ test {
             def output = "\nResults: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
             println(output)
         }
+    }
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.enabled = true
+        html.enabled = true
     }
 }
 


### PR DESCRIPTION
I'm using codecov.io as an easy way to upload coverage reports. In the past I've used internal tools, so I am not experienced with this one, but it looks OK and it's free for Open Source projects, so let's try it.

I'll need to merge this and try with a different PR.

Related issue: #4 