### PR TITLE
Logout form and endpoint

### DIFF
--- a/src/main/kotlin/com/github/dripolles/projectk/api/Home.kt
+++ b/src/main/kotlin/com/github/dripolles/projectk/api/Home.kt
@@ -17,7 +17,10 @@ fun Application.homeModule() {
         authenticate(AuthConfig.USER) {
             get(Routes.HOME) {
                 val userSession = call.sessions.get<UserSession>()!!
-                val model = mapOf("username" to userSession.username)
+                val model = mapOf(
+                    "username" to userSession.username,
+                    "logout" to Routes.LOGOUT
+                )
                 val content = PebbleContent("home.html", model)
                 call.respond(content)
             }

--- a/src/main/kotlin/com/github/dripolles/projectk/api/Login.kt
+++ b/src/main/kotlin/com/github/dripolles/projectk/api/Login.kt
@@ -13,6 +13,7 @@ import io.ktor.response.respondRedirect
 import io.ktor.routing.get
 import io.ktor.routing.post
 import io.ktor.routing.routing
+import io.ktor.sessions.clear
 import io.ktor.sessions.sessions
 import io.ktor.sessions.set
 
@@ -31,6 +32,10 @@ fun Application.loginModule() {
                 val principal = call.principal<UserIdPrincipal>()!!
                 call.sessions.set(UserSession(principal.username))
                 call.respondRedirect(Routes.HOME)
+            }
+            post(Routes.LOGOUT) {
+                call.sessions.clear<UserSession>()
+                call.respondRedirect(Routes.LOGIN)
             }
         }
     }

--- a/src/main/kotlin/com/github/dripolles/projectk/api/Routes.kt
+++ b/src/main/kotlin/com/github/dripolles/projectk/api/Routes.kt
@@ -3,4 +3,5 @@ package com.github.dripolles.projectk.api
 object Routes {
     const val HOME = "/"
     const val LOGIN = "/login"
+    const val LOGOUT = "/logout"
 }

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,5 +1,8 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h2>Logged in as {{username}}</h2>
+<h2>Logged in as {{ username }}</h2>
+<form method="POST" action="{{ logout }}">
+    <input type="submit" content="Logout">
+</form>
 {% endblock %}

--- a/src/test/kotlin/com/github/dripolles/projectk/api/LoginTest.kt
+++ b/src/test/kotlin/com/github/dripolles/projectk/api/LoginTest.kt
@@ -106,6 +106,8 @@ class LoginTest {
                 uri = Routes.LOGOUT
             }.apply {
                 assertNull(sessions.get<UserSession>())
+                assertEquals(HttpStatusCode.Found, response.status())
+                assertEquals(Routes.LOGIN, response.headers["Location"])
             }
         }
     }


### PR DESCRIPTION
Add a button for logout in the home page, and also the endpoint to deal with it. Logging out deletes the session in the server, and redirects the user to the login page again.

This solves issue #23 